### PR TITLE
Add throttle and zoom controls to make game playable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ enGits Lander Challenge
 - -: zoom out
 - shift +: increase simulation speed
 - shift -: descrease simulation speed
+- mouse wheel: zoom in/out
 
 ## Other keys
 - space-bar: cycle through reference objects

--- a/core/spacecraft.js
+++ b/core/spacecraft.js
@@ -7,7 +7,7 @@ export class Spacecraft extends Body {
     this.image.src = imageSrc;
     this.size = 20; // pixel size when drawn
     this.maxThrust = 45000; // Newtons
-    this.thrusting = false;
+    this.throttle = 0; // 0..1
     this.rotateDir = 0; // -1,0,1
     this.turnRate = Math.PI / 2; // rad/s
   }
@@ -19,12 +19,17 @@ export class Spacecraft extends Body {
     // thrust force in spacecraft frame
     let Fx = 0;
     let Fy = 0;
-    if (this.thrusting && this.mass > 0) {
-      Fx = this.maxThrust * Math.sin(this.alpha);
-      Fy = this.maxThrust * Math.cos(this.alpha);
+    if (this.throttle > 0 && this.mass > 0) {
+      const thrust = this.maxThrust * this.throttle;
+      Fx = thrust * Math.sin(this.alpha);
+      Fy = thrust * Math.cos(this.alpha);
     }
 
     super.updatePhysics(dt, Fx, Fy);
+  }
+
+  adjustThrust(delta) {
+    this.throttle = Math.min(1, Math.max(0, this.throttle + delta));
   }
 
   draw(ctx) {


### PR DESCRIPTION
## Summary
- Implement adjustable thrust for the spacecraft and display current thrust
- Add keyboard and mouse wheel zoom controls with bounds
- Document wheel-based zoom in README and improve in-game instructions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`
- `node --check core/spacecraft.js scenes/orbitGame.js main.js`

------
https://chatgpt.com/codex/tasks/task_e_68b443e0b400832abbdbb12a9d874983