### PR TITLE
Center zoom on spacecraft and add lunar mountains

### DIFF
--- a/core/body.js
+++ b/core/body.js
@@ -48,8 +48,9 @@ export class Body {
   screenPosition() {
     // convert world coordinates to screen space relative to reference body
     const ref = this.game.reference;
-    const dx = this.x - ref.x;
-    const dy = this.y - ref.y;
+    const target = this.game.cameraTarget || ref;
+    const dx = this.x - target.x;
+    const dy = this.y - target.y;
     const cos = Math.cos(-ref.alpha);
     const sin = Math.sin(-ref.alpha);
     const rx = dx * cos - dy * sin;
@@ -70,6 +71,12 @@ export class Body {
     ctx.arc(x, y, r, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
+
+    if (this.featureList) {
+      for (const feature of this.featureList) {
+        feature.draw(ctx);
+      }
+    }
   }
 }
 

--- a/core/surfaceFeature.js
+++ b/core/surfaceFeature.js
@@ -12,14 +12,15 @@ export class SurfaceFeature {
     // very simple projection of points to screen space
     if (!this.points.length) return;
     const ref = this.planet.game.reference;
+    const target = this.planet.game.cameraTarget || ref;
     const scale = this.planet.game.scaleFactor();
     const pts = [];
     const alpha = this.planet.alpha + this.theta;
     for (const [px, py] of this.points) {
       const x1 = px * Math.cos(alpha) - (py + this.planet.radius) * Math.sin(alpha);
       const y1 = px * Math.sin(alpha) + (py + this.planet.radius) * Math.cos(alpha);
-      const dx = x1 + this.planet.x - ref.x;
-      const dy = y1 + this.planet.y - ref.y;
+      const dx = x1 + this.planet.x - target.x;
+      const dy = y1 + this.planet.y - target.y;
       const cos = Math.cos(-ref.alpha);
       const sin = Math.sin(-ref.alpha);
       const rx = dx * cos - dy * sin;

--- a/scenes/orbitGame.js
+++ b/scenes/orbitGame.js
@@ -2,6 +2,7 @@ import { GameOver } from './gameOver.js';
 import { TutorialView } from './tutorial.js';
 import { Body } from '../core/body.js';
 import { Spacecraft } from '../core/spacecraft.js';
+import { Mountain } from '../core/mountain.js';
 
 export class OrbitGame {
   constructor(canvas, ctx, switchScene, level = 1) {
@@ -40,12 +41,24 @@ export class OrbitGame {
     this.planet.scaleFactor = 0.25 * Math.min(canvas.width, canvas.height) / this.planet.radius;
     this.reference = this.planet;
 
+    // Random mountains on the lunar surface
+    const Hmin = 100;
+    const Hmax = 6000;
+    for (let i = 0; i < 100; i++) {
+      const H = Hmin + Math.random() * (Hmax - Hmin);
+      const W = H + Math.random() * 2 * H;
+      const M = 0.25 * W + Math.random() * 0.5 * W;
+      const theta = Math.random() * Math.PI * 2;
+      new Mountain(this.planet, H, W, M, theta);
+    }
+
     // Spacecraft
     this.spacecraft = new Spacecraft('assets/craft_01.png', this);
     this.spacecraft.mass = 15000;
     this.spacecraft.y = this.planet.radius + 300000; // 300 km altitude
     this.spacecraft.u = Math.sqrt(Body.G * this.planet.mass / this.spacecraft.y);
     this.spacecraft.color = 'white';
+    this.cameraTarget = this.spacecraft;
 
     // Level setup placeholders
     if (this.level === 2) this.setLevel2();
@@ -148,7 +161,7 @@ export class OrbitGame {
     // Instructions
     ctx.fillStyle = 'white';
     ctx.font = '16px Courier New';
-    ctx.fillText('Arrow keys to fly. +/- or wheel to zoom. T for Tutorial, ESC to Quit', xOffset, canvas.height - yOffset);
+    ctx.fillText('Arrow keys to fly. +/- or wheel to zoom. SPACE to focus. T for Tutorial, ESC to Quit', xOffset, canvas.height - yOffset);
 
     if (this.showCrashed) {
       ctx.font = '40px Courier New';
@@ -174,6 +187,9 @@ export class OrbitGame {
       case 'KeyT':
         this.paused = true;
         this.switchScene(new TutorialView(this.canvas, this.ctx, this.switchScene, this));
+        break;
+      case 'Space':
+        this.cameraTarget = this.cameraTarget === this.spacecraft ? this.planet : this.spacecraft;
         break;
       case 'Escape':
         this.gameRunning = false;

--- a/scenes/tutorial.js
+++ b/scenes/tutorial.js
@@ -8,22 +8,26 @@ export class TutorialView {
     this.switchScene = switchScene;
     this.previousView = previousView;
     this.lines = [
-      'Press ESC to return',
-      'Press ENTER to restart',
-      'Press T in game for this help',
+      'How to Play',
+      '',
+      'Goal: land the spacecraft gently on the Moon.',
       '',
       '## Arrow Keys',
-      '- LEFT: Rotate left',
-      '- RIGHT: Rotate right',
-      '- UP: Increase throttle',
-      '- DOWN: Decrease throttle',
+      '- LEFT/RIGHT: Rotate craft',
+      '- UP: Increase thrust (Shift for +10%)',
+      '- DOWN: Decrease thrust (Shift for -10%)',
       '',
-      '## Zoom & Focus',
-      '- PLUS: Zoom in',
-      '- MINUS: Zoom out',
-      '- SPACE: Toggle focus',
+      '## NumPad',
+      '- 1: Control main craft',
+      '- 2: Control lander',
+      '- 0: Dock or undock',
       '',
-      'Press ESC to return'
+      '## Zoom & View',
+      '- Mouse wheel or +/-: Zoom in/out',
+      '- SPACE: Toggle camera focus',
+      '',
+      'Press T in game for this help',
+      'ESC: return, ENTER: restart'
     ];
   }
 


### PR DESCRIPTION
## Summary
- keep camera centered on spacecraft when zooming and draw planetary surface features
- render randomly generated lunar mountains and allow toggling camera focus with the space bar
- expand tutorial text with clearer game objectives and controls

## Testing
- `node --check core/body.js`
- `node --check core/surfaceFeature.js`
- `node --check scenes/orbitGame.js`
- `node --check scenes/tutorial.js`


------
https://chatgpt.com/codex/tasks/task_e_68b446b54564832a982820ffe9e68c89